### PR TITLE
RV-955: Fix deploy issue.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ recipe 'opsworks_sidekiq::deploy',    'Deploy sidekiq worker.'
 recipe 'opsworks_sidekiq::undeploy',  'Undeploy sidekiq worker.'
 recipe 'opsworks_sidekiq::stop',      'Stop sidekiq worker.'
 
-depends 'deploy'
+# depends 'deploy'


### PR DESCRIPTION
https://fundbase.atlassian.net/browse/RV-955

## Problem
Integration deploy is failing due to the following:
`STDERR: Unable to satisfy constraints on package deploy, which does not exist, due to solution constraint (opsworks_sidekiq = 0.0.0). Solution constraints that may result in a constraint on deploy: [(opsworks_sidekiq = 0.0.0) -> (deploy >= 0.0.0)]
Missing artifacts: deploy
Demand that cannot be met: (opsworks_sidekiq = 0.0.0)
Unable to find a solution for demands: fundbase (0.0.1), haproxy-latest (1.6.4), java (>= 0.0.0), mongo (0.0.1), mongodb (>= 0.0.0), nginx (2.7.4), nodejs (>= 0.0.0), ohai (>= 0.0.0), opsworks_sidekiq (0.0.0), r (0.3.0), r-analytics (0.0.1), runit (>= 0.0.0), rvm (>= 0.0.0), scout (0.4.0), scoutapp (0.0.1), sinatra (0.1.0), windows (~> 1.34.0)`

## Solution
This is issue is discussed here: https://github.com/joeyAghion/opsworks_delayed_job/issues/8
And implemented here: https://github.com/HealthyDelivery/opsworks_delayed_job/commit/8ac57e7241ef598af3b0b3847331c562f9a90a00
